### PR TITLE
fix: remove duplicate mapping keys in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,11 +330,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/plugin-transform-react-jsx-self@7.29.7':
     resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
     engines: {node: '>=6.9.0'}
@@ -5217,10 +5212,6 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/parser@7.29.7':
-    dependencies:
-      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:


### PR DESCRIPTION
The merge of #839 left two duplicated '@babel/parser@7.29.7' entries (one in packages:, one in snapshots:), producing invalid YAML with duplicate mapping keys. This broke `pnpm install --frozen-lockfile` (ERR_PNPM_BROKEN_LOCKFILE) and every Dependabot update run since, which is why recent "npm_and_yarn ... Update" workflow runs have been failing.

Verified pnpm install --frozen-lockfile, lint, test, and build all pass after removing the duplicates.