### PR TITLE
fix: close dependabot auto-merge race condition

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,7 @@ updates:
     rebase-strategy: "auto"
     open-pull-requests-limit: 10
     groups:
-      patch-updates:
+      routine-updates:
         update-types:
           - "patch"
-      minor-updates:
-        update-types:
           - "minor"


### PR DESCRIPTION
## Summary
- `main`'s branch protection had no required status checks and no "up to date before merge" requirement, so `dependabot-automerge.yml`'s `gh pr merge --auto` merged grouped Dependabot PRs immediately without waiting for `main-ci` or rebasing onto the latest `main`.
- With separate `patch-updates`/`minor-updates` groups often open at the same time, back-to-back auto-merges could squash in stale, overlapping lockfile diffs — this is exactly what corrupted `pnpm-lock.yaml` when #838 and #839 merged 106 seconds apart (fixed separately in `fix/pnpm-lockfile-duplicate-keys`).
- Branch protection on `main` has already been updated directly (not part of this diff) to require the `validate` check on an up-to-date branch before merging, and repo-level `allow_auto_merge` is now enabled.
- This PR further shrinks the race window by merging `patch-updates` and `minor-updates` into a single `routine-updates` group, so normally only one grouped PR is open at a time instead of two.

## Test plan
- [x] Confirmed `.github/dependabot.yml` is valid YAML
- [x] `pnpm test` passes (via pre-commit hook)
- [ ] Watch the next scheduled Dependabot run to confirm it opens a single combined group PR and that auto-merge now waits for `main-ci` before merging